### PR TITLE
[FEATURE] Utiliser l'action d'`auto-merge` composite

### DIFF
--- a/.github/workflows/auto-merge-local.yml
+++ b/.github/workflows/auto-merge-local.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   automerge:
-    uses: "1024pix/pix-actions/.github/workflows/auto-merge.yml@v0.1.0"
-    secrets:
-      auto_merge_token: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 1024pix/pix-actions/auto-merge@6575d94a9672fa3573470a1bed8e7dce0315f60f
+        with:
+          auto_merge_token: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"


### PR DESCRIPTION
Permet de ne pas mettre notre action dans `.github/workflows` (ce qui porte à confusion).