### PR TITLE
[FEATURE] Ajouter le numéro de PR dans la description du commit de merge

### DIFF
--- a/auto-merge/action.yml
+++ b/auto-merge/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: ':rocket: Ready to Merge,!:warning: Blocked,!:earth_africa: i18n needed,!:busts_in_silhouette: Panel Review Needed,!Development in progress,!:eyes: Design Review Needed,!:eyes: Func Review Needed,!:eyes: Tech Review Needed'
   merge_commit_message: 
     type: string
-    default: pull-request-title
+    default: '{pullRequest.title} \n\n #{pullRequest.number}'
   update_labels: 
     type: string
     default: ':rocket: Ready to Merge'


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous n'avons pas le numéro de la PR dans la description du commit de merge. Cette information est inutile lorsqu'on fait de l'archéologie ou qu'on veut générer le changelog par exemple ;) 

## :robot: Proposition
Ajouter cette information

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Voir le test : https://github.com/1024pix/conventional-changelog-pix/commit/dbad72b4e06b994ebc9491dee44dac9175b6890f