### PR TITLE
[BUGFIX] Afficher correctement les retours à la ligne pour construire le message de merge

### DIFF
--- a/auto-merge/action.yml
+++ b/auto-merge/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: ':rocket: Ready to Merge,!:warning: Blocked,!:earth_africa: i18n needed,!:busts_in_silhouette: Panel Review Needed,!Development in progress,!:eyes: Design Review Needed,!:eyes: Func Review Needed,!:eyes: Tech Review Needed'
   merge_commit_message: 
     type: string
-    default: '{pullRequest.title} \n\n #{pullRequest.number}'
+    default: "{pullRequest.title} \n\n #{pullRequest.number}"
   update_labels: 
     type: string
     default: ':rocket: Ready to Merge'


### PR DESCRIPTION
## :unicorn: Problème
Lors d'un essai le numéro de PR s'est retrouvé sur la même ligne et les retours alignés n'ont pas fonctionné : https://github.com/1024pix/conventional-changelog-pix/commit/0d3fe7920b4d2abd074a7c1ebd038532bdbe8b4d 

## :robot: Proposition
La différence avec le test qui avait été fait est les doubles quotes 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
