### PR TITLE
[BUGFIX] Réparer l'action release

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -30,7 +30,7 @@ runs:
       id: semantic
       uses: cycjimmy/semantic-release-action@v4
       with:
-        semantic_version: 22.0.5
+        semantic_version: 23
         extra_plugins: |
           @semantic-release/changelog@6
           @semantic-release/git@10

--- a/release/action.yml
+++ b/release/action.yml
@@ -35,7 +35,7 @@ runs:
           @semantic-release/changelog@6
           @semantic-release/git@10
         extends: |
-          @1024pix/conventional-changelog-pix@1
+          @1024pix/conventional-changelog-pix@2
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ env.NPM_TOKEN }}


### PR DESCRIPTION
## :unicorn: Problème
Depuis un moment l'action release ne fonctionne plus, car semantic-release a changé sa façon d'importer les plugins.

## :robot: Proposition
Nous avons fait évoluer notre plugin conventional-changelog-pix, et nous devons mettre à jour l'action pour qu'elle utilise la nouvelle version majeure.
De plus, nous en profitons pour passer à semantic-release 23 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
