### PR TITLE
[BUGFIX] Mettre à jour sur git le package.json lors d'une release.

### DIFF
--- a/release/release.config.cjs
+++ b/release/release.config.cjs
@@ -37,6 +37,8 @@ module.exports = {
       {
         "assets": [
           "CHANGELOG.md",
+          "package.json",
+          "package-lock.json",
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, quand semantic-release fait son commit de release, le package.json reste intact. 

## :robot: Proposition
En regardant les logs, nous pouvons voir : 
![Screenshot 2024-02-07 at 14 37 13](https://github.com/1024pix/pix-actions/assets/26384707/50ebda65-01c8-4160-bdf8-0f4d9aade749)

De plus, lors qu'on va sur une release npm, le package.json a bien la version à jour.

Il s'agit donc bien d'un problème lié au commit, en regardant de plus près [la documentation du package `@semantic-release/git`](https://github.com/semantic-release/git?tab=readme-ov-file#options), nous pouvons voir : 
![Screenshot 2024-02-07 at 14 40 23](https://github.com/1024pix/pix-actions/assets/26384707/68ad2d92-fee5-45be-9f35-542f04a1d602)


La solution est donc d'ajouter dans les assets les deux fichiers package.json et package-lock.json

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
