### PR TITLE
[BUGFIX] Utiliser uniquement les commits de merges pour les releases. 

### DIFF
--- a/release/release.config.cjs
+++ b/release/release.config.cjs
@@ -9,12 +9,12 @@ module.exports = {
       {
         "config": "@1024pix/conventional-changelog-pix",
         "releaseRules": [
-          { tag: "BUGFIX", release: "patch" },
-          { tag: "BUMP", release: "patch" },
-          { tag: "DOC", release: "patch" },
-          { tag: "TECH", release: "patch" },
-          { tag: "FEATURE", release: "minor" },
-          { tag: "BREAKING", release: "major" },
+          { tag: "BUGFIX", pr: '*', release: "patch" },
+          { tag: "BUMP", pr: '*', release: "patch" },
+          { tag: "DOC", pr: '*', release: "patch" },
+          { tag: "TECH", pr: '*', release: "patch" },
+          { tag: "FEATURE", pr: '*', release: "minor" },
+          { tag: "BREAKING", pr: '*', release: "major" },
         ],
       }
     ],


### PR DESCRIPTION
## :unicorn: Problème
Si on regarde, le changelog ou bien les releases GitHub, la section “Montée de version” a un soucis : 

![Screenshot 2024-03-06 at 14 51 02](https://github.com/1024pix/pix-actions/assets/26384707/640e4446-3f81-40a4-b25f-816cc4fdc33a)


Chaque PR faite par Renovate apparait deux fois. Cela est dû au fait que Renovate, a un titre de commit qui va ensuite être répercuté en titre de PR. 
J’ai pu modifier la configuration de Renovate pour avoir un commit sous le format conventional-commit et un titre de PR qui correspond à nos standards : 

![Screenshot 2024-03-06 at 14 53 28](https://github.com/1024pix/pix-actions/assets/26384707/daf382c0-5041-4fb1-b6ab-7df736ea5d4d)

Cependant, cela avait pour conséquence de mettre tout le titre de PR en minuscule, ce qui nous convient pas. 
De plus, l’option `prTitle` est dépréciée : 

![Screenshot 2024-03-06 at 14 53 28](https://github.com/1024pix/pix-actions/assets/26384707/e828b6aa-5b63-41ac-a134-14b2983ddd20)

C’est donc pas très pérenne de se baser dessus.

Je me demande ce que je peux faire du côté de `semantic-release` et `conventional-changelog-pix`

Du côté de [semantic-release](https://github.com/semantic-release/semantic-release), les commits sont récupérés grâce à [une fonction interne getCommits](ttps://github.com/semantic-release/semantic-release/blob/9fd0ab7c35a4815450635d7696bac47e3ebd9901/index.js#L120) qui ne prend pas d’option de l’extérieur, dommage, car en dessous ça utilise  [git-log-parser](http://www.npmjs.com/package/git-log-parser) et cette librairie accepte toutes les options de la commande git log dont --merges

Ensuite, du côté de [@semantic/commit-analyzer](https://github.com/semantic-release/commit-analyzer) rien à faire la lib itère sur les commits passés par semantic-release, utilise le parser de conventional-changelog-parser et une configuration de parser, pour nous c’est conventional-changelog-pix, puis cela applique les règles fournies en config. 

Donc, il faudrait plutôt se pencher sur conventional-changelog-pix, pour ne pas retourner de tag quand c’est pas un commit de merge. 

Comment marche conventional-changelog-pix : c’est juste des regex qui sont appliquées par le parser conventional-changelog-parser. C’est d’ailleurs pas si explicite, j’ajoute donc des tests pour améliorer ça. 

Par contre, ce qui est embêtant, c’est que notre élément différenciant entre le commit de merge et le commit, c’est qu’on a le numéro de PR dans le cas de la PR de merge. Mais le parser prend un commit et split toutes les lignes du commit pour les analyser, on ne peut donc pas faire une regex qui matcherait et la première ligne et la seconde. C'est donc pas du côté de cette librairie que le souci va être résolu. 
Et nous voilà ici. 

## :robot: Proposition
Actuellement, `semantic-release` se base sur les commits qui ont des tags pour choisir le type de version, comme ce n'est pas suffisant pour matcher les commits de merges, nous ajoutons `pr: '*'`, pour s'assurer que pr ne soit pas à nulle. (cf: [les tests du côté de conventional-changelog-pix](https://github.com/1024pix/conventional-changelog-pix/pull/33/files) qui montre que pr n'est pas toujours rempli)  

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
