### PR TITLE
[DOC] Affiner la documentation de l'action `release`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ jobs:
       
       - uses: 1024pix/pix-actions/release@main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GH_TOKEN }} # Use PAT with repo scope, and user related should have admin access if main branch is protected
 ```
-</details>
+
 
 ### Configuration 
 
@@ -135,7 +135,7 @@ jobs:
         with:
           npmPublish: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GH_TOKEN }} # Use PAT with repo scope, and user related should have admin access if main branch is protected
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
@@ -157,6 +157,6 @@ jobs:
         with: 
           updateMajorVersion: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GH_TOKEN }} # Use PAT with repo scope, and user related should have admin access if main branch is protected
 ```
-
+</details>


### PR DESCRIPTION
## :unicorn: Problème
La description de l'action release utilise le secret fourni par GitHub durant l'action, cependant il n'a pas les droits suffisant dans certains cas.

## :robot: Proposition
Améliorer la documentation à ce sujet

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
