### PR TITLE
[FEATURE] Propager les variables faites pas l'action semantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       
       - uses: 1024pix/pix-actions/release@main
         env:
@@ -123,6 +125,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -152,6 +156,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       
       - uses: 1024pix/pix-actions/release@main
         with: 

--- a/release/action.yml
+++ b/release/action.yml
@@ -41,6 +41,16 @@ runs:
         NPM_TOKEN: ${{ env.NPM_TOKEN }}
         NPM_PUBLISH: ${{ inputs.npmPublish }}
 
+    - name: share variables
+      if: steps.semantic.outputs.new_release_published == 'true'
+      run: | 
+        echo "new_release_published=${{ steps.semantic.outputs.new_release_published }}" >> $GITHUB_ENV
+        echo "new_release_version=${{ steps.semantic.outputs.new_release_version }}" >> $GITHUB_ENV
+        echo "new_release_major_version=${{ steps.semantic.outputs.new_release_major_version }}" >> $GITHUB_ENV
+        echo "new_release_minor_version=${{ steps.semantic.outputs.new_release_minor_version }}" >> $GITHUB_ENV
+        echo "new_release_patch_version=${{ steps.semantic.outputs.new_release_patch_version }}" >> $GITHUB_ENV
+      shell: bash
+
     - name: Push updates to branch for major version
       if: steps.semantic.outputs.new_release_published == 'true' && inputs.updateMajorVersion == 'true'
       run: "git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v${{steps.semantic.outputs.new_release_major_version}}"


### PR DESCRIPTION
## :unicorn: Problème
Quand nous essayons d'utiliser les variables écrite pas l'action `cycjimmy/semantic-release-action` nous obtenons rien.

## :robot: Proposition
Remonter nous mêmes les variables à l'action qui appelle l'action `release`

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
