### PR TITLE
[FEATURE] Déclencher une release pour une PR de revert

### DIFF
--- a/release/release.config.cjs
+++ b/release/release.config.cjs
@@ -9,6 +9,7 @@ module.exports = {
       {
         "config": "@1024pix/conventional-changelog-pix",
         "releaseRules": [
+          { revert: true, release: "patch" },
           { tag: "BUGFIX", pr: '*', release: "patch" },
           { tag: "BUMP", pr: '*', release: "patch" },
           { tag: "DOC", pr: '*', release: "patch" },


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les PR de revert ne déclenchait pas de release. La première raison, notre parser ne gérait pas les revert : https://github.com/1024pix/conventional-changelog-pix/pull/35, mais c'est révolu. 
Reste qu'on doit dire dans la config de semantic-release quel type de version nous souhaitons.

## :robot: Proposition
Créer la règle pour le revert pour dire que ça déclenche une release de type `patch`

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
