### PR TITLE
[FEATURE] Améliorer la vérification des titres des PRs.

### DIFF
--- a/check-pr-title/action.yml
+++ b/check-pr-title/action.yml
@@ -12,4 +12,4 @@ runs:
       if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
       uses: Slashgear/action-check-pr-title@v4.3.0
       with:
-        regexp: '^(\[[A-Z]+\]|Revert) '
+        regexp: '^(\[(BUGFIX|FEATURE|TECH|BUMP|DOC|POC)\]|Revert) '


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le contributing "autorise" uniquement quelques tags dans le titre de la PR. Cependant, rien nous oblige d'utiliser ceux-ci précisément ce qui peut créer des ambiguités et cela a l'inconvénient de placer les PR avec un tag peu commun dans la section AUTRES du changelog au lieu d'être dans la bonne section : 

![Screenshot 2024-05-22 at 15 06 52](https://github.com/1024pix/pix-actions/assets/26384707/f4053ebd-fe95-4e44-86f9-e415c8b2c43c)


## :robot: Proposition
Faire en sorte que les tags soient uniquement ceux autorisés.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- S'amuser avec le titre de cette PR