### PR TITLE
[FEATURE] Ajouter la possibilité d'utiliser le tag "BREAKING"

### DIFF
--- a/check-pr-title/action.yml
+++ b/check-pr-title/action.yml
@@ -12,4 +12,4 @@ runs:
       if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
       uses: Slashgear/action-check-pr-title@v4.3.0
       with:
-        regexp: '^(\[(BUGFIX|FEATURE|TECH|BUMP|DOC|POC)\]|Revert) '
+        regexp: '^(\[(BUGFIX|FEATURE|TECH|BUMP|DOC|POC|BREAKING)\]|Revert) '


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous pouvons utiliser le tag "BREAKING" sur Pix UI, et [le changelog le permet](https://github.com/1024pix/pix-actions/blob/3a14b7d08d80d51ac71522ae6c4a25f56a219387/release/release.config.cjs#L18), mais le linter de titre de PR ne le permet pas.

## :robot: Proposition
Ajouter le tag

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
