### PR TITLE
[BUGFIX] Autoriser le merge provenant de fork

### DIFF
--- a/auto-merge/action.yml
+++ b/auto-merge/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: rebase
   merge_forks:
     type: string
-    default: 'false'
+    default: 'true'
 
 runs:
   using: composite


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous ne pouvons pas merger les PRs provenant de fork

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
