### PR TITLE
[FEATURE] Ajouter une nouvelle action d'auto-merge 

### DIFF
--- a/.github/workflows/auto-merge-dispatch.yml
+++ b/.github/workflows/auto-merge-dispatch.yml
@@ -1,0 +1,47 @@
+name: automerge check
+
+on:
+  workflow_dispatch:
+    inputs:
+      pullRequest:
+        description: 'Pull request préfixé par le nom du repo : 1024pix/pix'
+        required: true
+
+
+inputs:
+  auto_merge_token:
+    required: true
+  merge_labels:
+    type: string
+    default: ':rocket: Ready to Merge,!:warning: Blocked,!:earth_africa: i18n needed,!:busts_in_silhouette: Panel Review Needed,!Development in progress,!:eyes: Design Review Needed,!:eyes: Func Review Needed,!:eyes: Tech Review Needed'
+  merge_commit_message:
+    type: string
+    default: "{pullRequest.title} \n\n #{pullRequest.number}"
+  update_labels:
+    type: string
+    default: ':rocket: Ready to Merge'
+  update_method:
+    type: string
+    default: rebase
+  merge_forks:
+    type: string
+    default: 'false'
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: | 
+          echo '${{ input.pull_request }}'
+#      - name: automerge
+#        uses: pascalgn/automerge-action@v0.16.4
+#        env:
+#          GITHUB_TOKEN: '${{ inputs.auto_merge_token }}'
+#          MERGE_LABELS: '${{ inputs.merge_labels }}'
+#          MERGE_COMMIT_MESSAGE: '${{ inputs.merge_commit_message }}'
+#          UPDATE_LABELS: '${{ inputs.update_labels }}'
+#          UPDATE_METHOD: '${{ inputs.update_method }}'
+#          MERGE_FORKS: '${{ inputs.merge_forks }}'
+#          PULL_REQUEST: '${{ inputs.pullRequest }}'
+


### PR DESCRIPTION
## :fallen_leaf: Problème
Actuellement, nous devons ajouter notre action d'auto-merge sur chaque repo de l'organisation. Grâce à la [PR](https://github.com/1024pix/pix-bot/pull/447/), nous n'en avons plus besoin si nous avons une action qui accepte d'être déclenché par appel API, sachant que l['action sous-jaccente](https://github.com/pascalgn/automerge-action) permet de merger un repo distant. 

## :chestnut: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
