### PR TITLE
[BUGFIX] Appeler Pix Bot quand l'automerge failed

### DIFF
--- a/.github/workflows/auto-merge-dispatch.yml
+++ b/.github/workflows/auto-merge-dispatch.yml
@@ -41,7 +41,7 @@ jobs:
           MERGE_RETRY_SLEEP: "30000"
 
       - name: Call Pix Bot
-        if: ${{ steps.automerge.outputs.mergeResult != 'merged' }}
+        if: ${{ steps.automerge.outputs.mergeResult != 'merged' ||  steps.automerge.outcome != 'success' }}
         run: |
           curl ${{ secrets.PIX_BOT_URL }}/merge?status=failure -d '{"pullRequest": "${{ inputs.pullRequest }}"  }' -H 'Authorization: Bearer ${{ secrets.PIX_BOT_TOKEN }}' -H 'Content-type: application/json'
 


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, lorsque l'étape pascalgn/automerge-action est en erreur, les valeurs de retour ne sont pas remplies ce qui ne permet pas d'envoyer le status de failed à Pix Bot. La merge queue est alors bloquée. 

## :gift: Proposition

Utiliser le outcome proposé par GitHub

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
