### PR TITLE
[FEATURE] Ajouter du contexte dans le nom de l'action

### DIFF
--- a/.github/workflows/auto-merge-dispatch.yml
+++ b/.github/workflows/auto-merge-dispatch.yml
@@ -1,4 +1,5 @@
 name: automerge
+run-name: automerge ${{ inputs.pullRequest }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## :christmas_tree: Problème
La liste des runs de l'action automerge est longue et il faut rentrer dans chaque run pour retrouver les causes d'erreurs de merge de sa PR. 

## :gift: Proposition

Utiliser [run-name](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#name) qui permet de donner du context au nom du run de l'action

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
