### PR TITLE
[FEATURE] Lancer l'appel à Pix Bot à chaque fois que l'action auto-merge est en échec

### DIFF
--- a/.github/workflows/auto-merge-dispatch.yml
+++ b/.github/workflows/auto-merge-dispatch.yml
@@ -42,7 +42,7 @@ jobs:
           MERGE_RETRY_SLEEP: "30000"
 
       - name: Call Pix Bot
-        if: ${{ steps.automerge.outputs.mergeResult != 'merged' ||  steps.automerge.outcome != 'success' }}
+        if: ${{ always() && (steps.automerge.outputs.mergeResult != 'merged' ||  steps.automerge.outcome != 'success') }}
         run: |
           curl ${{ secrets.PIX_BOT_URL }}/merge?status=failure -d '{"pullRequest": "${{ inputs.pullRequest }}"  }' -H 'Authorization: Bearer ${{ secrets.PIX_BOT_TOKEN }}' -H 'Content-type: application/json'
 


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsque l'action est en échec, le call à Pix Bot ne se fait pas et la merge queue est par conséquent bloquée. 

## :gift: Proposition

Ajouter always() pour que l'étape soit lancée à chaque fois 

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
