### PR TITLE
[FEATURE] Mettre à jour tous les packages.json des sous dossiers des repositories (PIX-17050).

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -34,6 +34,7 @@ runs:
         extra_plugins: |
           @semantic-release/changelog@6
           @semantic-release/git@10
+          @semantic-release/exec@6
         extends: |
           @1024pix/conventional-changelog-pix@2
       env:

--- a/release/action.yml
+++ b/release/action.yml
@@ -18,6 +18,11 @@ inputs:
       Whether to update the major version or not. If set to true, the major
       version will be updated.
     default: false
+  changelogTitle:
+    required: false
+    description: >-
+      Title of the CHANGELOG.md file if there is one
+    default: undefined
 
 runs:
   using: composite
@@ -41,6 +46,7 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ env.NPM_TOKEN }}
         NPM_PUBLISH: ${{ inputs.npmPublish }}
+        CHANGELOG_TITLE: ${{ inputs.changelogTitle }}
 
     - name: share variables
       if: steps.semantic.outputs.new_release_published == 'true'

--- a/release/release.config.cjs
+++ b/release/release.config.cjs
@@ -34,12 +34,20 @@ module.exports = {
       }
     ],
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "find . -mindepth 2 -maxdepth 3 -name 'package.json' -not -path '*/node_modules/*' -execdir sh -c 'npm version \"$0\" --git-tag-version=false' \"${nextRelease.type}\" \\;",
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": [
           "CHANGELOG.md",
           "package.json",
           "package-lock.json",
+          "**/package.json",
+          "**/package-lock.json",
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }

--- a/release/release.config.cjs
+++ b/release/release.config.cjs
@@ -1,3 +1,11 @@
+const semanticReleaseChangelog =
+  process.env.CHANGELOG_TITLE === 'undefined' ?
+    "@semantic-release/changelog" :
+  [
+    "@semantic-release/changelog",
+    { "changelogTitle": process.env.CHANGELOG_TITLE },
+  ];
+
 module.exports = {
   "branches": [
     "main",
@@ -25,7 +33,7 @@ module.exports = {
         "config": "@1024pix/conventional-changelog-pix"
       }
     ],
-    "@semantic-release/changelog",
+    semanticReleaseChangelog,
     "@semantic-release/github",
     [
       "@semantic-release/npm",


### PR DESCRIPTION
## 🌸 Problème

Actuellement, l'action `release` met à jour uniquement le package.json à la racine. 


## 🌳 Proposition

Mettre à jour tous les sous package.json

## 🐝 Remarques

On pourrait mettre un script de pre-version sur le monorepo 🤔

## 🤧 Pour tester

Constater le bon fonctionnement : https://github.com/1024pix/pix-sementic-version/commit/8e6edff65ad907eba9db24a9050f74d7a4f37155
