### PR TITLE
[BUGFIX] Ne pas inclure les package.json et package-lock.json des dossiers node_modules

### DIFF
--- a/release/release.config.cjs
+++ b/release/release.config.cjs
@@ -54,8 +54,7 @@ module.exports = {
           "CHANGELOG.md",
           "package.json",
           "package-lock.json",
-          "**/package.json",
-          "**/package-lock.json",
+          ["**/package.json", "**/package-lock.json", "!**/node_modules/**/*.json"],
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }


### PR DESCRIPTION
## 🌸 Problème
L'action semantic-release/git ne prend pas en compte le fichier .gitignore ce qui a eu pour conséquence de commiter les `package.json` et `package-lock.json` du dossier `node_modules` :
```
Note: If a file has a match in assets it will be included even if it also has a match in .gitignore.
```

## 🌳 Proposition
- Exclure les dossiers `node_modules` des assets de semantic-release/git

## 🤧 Pour tester
Testé sur des forks de [pix-ui](https://github.com/1024pix/pix-ui-test-release/commit/89fbe55a4ca7e8788120afb9ed2f2da814f5e089) et [pix](https://github.com/1024pix/pix-test-release/commit/12378b57f6b8e64b8f20a6fd60579c5da07f677c).