### PR TITLE
[FEATURE] Permettre la création de releases depuis les hotfix.

### DIFF
--- a/release/release.config.cjs
+++ b/release/release.config.cjs
@@ -24,7 +24,8 @@ const npmPlugin = process.env.HAS_NPM_PACKAGES === 'true' ? [
 module.exports = {
   "branches": [
     "main",
-    "dev"
+    "dev",
+    "hotfix.*"
   ],
   "plugins": [
     [


### PR DESCRIPTION
## 🥀 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Dans la PR https://github.com/1024pix/pix-actions/pull/74, nous avons tenté de permettre à l'action de release de s'exécuter depuis des branches préfixées par `hotfix`.
Cela n'a pas fonctionner car la documentation de référence prise en compte était celle des Github Actions (qui prennent des blobs) au lieu de celle de l'action Semantic Release qui prend des expressions régulières (voir https://github.com/marketplace/actions/action-for-semantic-release#branches).

## 🏹 Proposition

Utiliser une expression régulière ("hotfix.\*") pour autoriser les branches préfixées `hotfix` à exécuter le workflow de release.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

J'ai tenté, sans succès, d'utiliser [act](https://github.com/nektos/act). J'ai eu des erreurs de communications avec Github que je n'ai pas su résoudre facilement.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
