### PR TITLE
[FEATURE] Ajouter une action pour fermer les anciennes pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# MacOS
+**/.DS_Store
+
+# Jetbrains IDEA
+**/.idea
+.idea

--- a/README.md
+++ b/README.md
@@ -280,3 +280,34 @@ jobs:
       REGISTRY_USERNAME: ${{ secrets.CUSTOM_REGISTRY_USERNAME }}
       REGISTRY_TOKEN: ${{ secrets.CUSTOM_REGISTRY_TOKEN }}
 ```
+
+## close-old-pull-requests
+Une actions qui permet de fermer les pull requests qui n'ont pas été mises à jour depuis un certain temps. Utile pour éviter d'avoir des PRs qui traînent sans être traitées.
+### Utilisation
+<details>
+  <summary><code>.github/workflows/close-old-pull-requests.yml</code></summary>
+
+```yaml
+name: Check Inactive Pull Requests
+
+on:
+  schedule:
+    # Runs every Monday at 9:00 AM
+    - cron: '0 9 * * 1'
+  # Allow manual execution
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: write
+
+jobs:
+  check-inactive-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pix-actions/close-old-pull-requests@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+</details>

--- a/close-old-pull-requests/action.yml
+++ b/close-old-pull-requests/action.yml
@@ -1,0 +1,41 @@
+name: Close old pull requests
+description: >-
+  Close inactive pull requests that have not been updated for a specified number of days.
+inputs:
+  token:
+    type: string
+    description: 'GitHub token with permissions to close pull requests.'
+    required: true
+os: ubuntu-latest
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Close old pull requests
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      run: |
+        ONE_MONTH_AGO=$(date -d "30 days ago" +%Y-%m-%dT%H:%M:%SZ)
+        echo "Searching opened pull requests from $ONE_MONTH_AGO"
+        OPENED_PRS=$(gh pr list --json number,updatedAt --limit 100)
+        PR_COUNT=$(echo "$OPENED_PRS" | jq '. | length')
+        echo "Found $PR_COUNT PRs opened"
+
+        echo "$OPENED_PRS" | jq -c '.[]' | while read -r PR; do
+          PR_NUMBER=$(echo "$PR" | jq -r '.number')
+          UPDATED_AT=$(echo "$PR" | jq -r '.updatedAt')
+
+          if [[ "$UPDATED_AT" < "$ONE_MONTH_AGO" ]]; then
+            echo "[#$PR_NUMBER] inactive PR since $UPDATED_AT"
+
+            gh pr close "$PR_NUMBER" --comment "Cette pull request a été fermée car elle est inactive depuis un mois. Vous pouvez la réouvrir ou la mettre en draft pour éviter qu'elle ne soit refermée." --delete-branch
+
+            echo "[#$PR_NUMBER] PR closed."
+          else
+            echo "[#$PR_NUMBER] active PR since $UPDATED_AT"
+          fi
+        done
+        echo "All inactive pull requests have been processed."


### PR DESCRIPTION
## 💥 Problème

L'action de fermeture des vieilles pull requests est maintenant en place depuis environ 1 an sur le monorepo voir https://github.com/1024pix/pix/pull/12215.

## 👩‍🚀 Proposition

Centraliser cette action dans pix-action pour pouvoir l'appeler depuis les autres repos.

## 👁️ Remarques

On pourrait variabiliser davantage, mais je ne l'ai pas fait par souci de simplicité.

## ♻️ Pour tester
- Merger la pr,
- Utiliser l'action depuis les dépôts.