### PR TITLE
[TECH] Ajoute une action pour build les fichiers docker bake

### DIFF
--- a/.github/workflows/docker-bake.yml
+++ b/.github/workflows/docker-bake.yml
@@ -1,0 +1,66 @@
+name: Docker generic Bake
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: 'Runner to use for the job'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      files:
+        description: 'List of bake files'
+        required: false
+        type: string
+      targets:
+        description: 'List of bake targets'
+        required: false
+        type: string
+      set:
+        description: 'List of bake overrides'
+        required: false
+        type: string
+      vars:
+        description: 'List of bake variables'
+        required: false
+        type: string
+    secrets:
+      REGISTRY_ENDPOINT:
+        required: false
+      REGISTRY_USERNAME:
+        required: false
+      REGISTRY_TOKEN:
+        required: false
+
+jobs:
+  bake:
+    runs-on: ${{ inputs.runs-on }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_ENDPOINT }}
+          username: ${{ secrets.REGISTRY_USERNAME || 'nologin' }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Build and push with Docker Bake
+        uses: docker/bake-action@v7
+        with:
+          files: ${{ inputs.files }}
+          targets: ${{ inputs.targets }}
+          set: ${{ inputs.set }}
+          push: true
+          vars: |
+            REGISTRY=${{ secrets.REGISTRY_ENDPOINT }}
+            ${{ inputs.vars }}
+
+      - name: Build summary
+        run: |
+          echo "## 🐳 Docker Bake completed successfully" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -280,3 +280,56 @@ jobs:
       REGISTRY_USERNAME: ${{ secrets.CUSTOM_REGISTRY_USERNAME }}
       REGISTRY_TOKEN: ${{ secrets.CUSTOM_REGISTRY_TOKEN }}
 ```
+
+## Docker Bake
+
+Workflow réutilisable pour construire et pousser des images Docker en utilisant Docker Bake.
+
+### Fonctionnalités
+
+- **Build multi-cibles** : Construit plusieurs cibles définies dans vos fichiers bake
+- **Registry flexible** : Compatible avec tout registry Docker (Scalingo, AWS ECR, etc.)
+- **Cache intelligent** : Permet de définir des caches par cible
+
+### Utilisation
+
+**Fichiers d'exemples disponibles** : Consultez le dossier [`docker-bake/examples/`](./docker-bake/examples/) pour des exemples complets.
+
+### Configuration
+
+#### Paramètres
+
+- `runs-on` : Runner à utiliser (optionnel, défaut: `ubuntu-latest`)
+- `files` : Liste des fichiers bake (optionnel)
+- `targets` : Liste des cibles à construire (optionnel)
+- `set` : Liste des overrides, utile pour configurer docker bake, comme avec le cache (optionnel)
+- `vars` : Liste des variables à passer à Docker Bake (optionnel)
+
+#### Utilisation des variables
+
+Vous pouvez passer des variables à Docker Bake via le paramètre `vars`. Cela permet de surcharger des variables définis dans vos fichiers HCL :
+
+```yaml
+jobs:
+  bake:
+    uses: 1024pix/pix-actions/.github/workflows/docker-bake.yml@main
+    with:
+      files: docker-bake.hcl
+      set: |
+        ENV_NAME=prod
+        TAG=latest
+```
+
+#### Secrets du registry
+
+```yaml
+jobs:
+  bake:
+    uses: 1024pix/pix-actions/.github/workflows/docker-bake.yml@main
+    with:
+      files: |
+        docker-bake.hcl
+    secrets:
+      REGISTRY_ENDPOINT: ${{ secrets.CONTAINER_REGISTRY_SCW_INFRA_ENDPOINT }}
+      REGISTRY_TOKEN: ${{ secrets.SCW_CONTAINER_REGISTRY_INFRA_SECRET_KEY }}
+```

--- a/docker-bake/examples/docker-bake-main.yml
+++ b/docker-bake/examples/docker-bake-main.yml
@@ -1,0 +1,27 @@
+name: Docker Bake Main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push-image:
+    uses: 1024pix/pix-actions/.github/workflows/docker-bake.yml@main
+    with:
+      files: |
+        docker-bake.hcl
+      targets: |
+        pix-site
+        pix-pro
+      vars: |
+        NODE_ENV=production
+        TAG=latest
+      set: |
+        pix-site.cache-from=type=gha,scope=pix-site
+        pix-pro.cache-from=type=gha,scope=pix-pro
+        pix-site.cache-to=type=gha,scope=pix-site,mode=max
+        pix-pro.cache-to=type=gha,scope=pix-pro,mode=max
+    secrets:
+      REGISTRY_ENDPOINT: ${{ secrets.CONTAINER_REGISTRY_SCW_INFRA_ENDPOINT }}
+      REGISTRY_TOKEN: ${{ secrets.SCW_CONTAINER_REGISTRY_INFRA_SECRET_KEY }}


### PR DESCRIPTION
## 💥 Problème

Docker bake est un orchestrateur de build d'image docker.
Il permet d'optimiser la chaine de build, la définition du cache, la gestion des variables.

Nous avons une action pour construire des images docker, mais pas d'action qui prend en compte les fichiers bake

## 👩‍🚀 Proposition

J'ai créé une action qui permet de build les images docker via des fichiers bake.

