### PR TITLE
add GH_TOKEN secret

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,6 +23,8 @@ on:
         required: false
       SCW_CONTAINER_REGISTRY_INFRA_SECRET_KEY:
         required: false
+      GH_TOKEN:
+        required: false
 
 jobs:
   build:


### PR DESCRIPTION
## 🪧 Problème

The workflow is not valid. .github/workflows/docker-main.yml (Line: 29, Col: 17): Invalid secret, GH_TOKEN is not defined in the referenced workflow.

## 🌈 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
